### PR TITLE
Manager and copier improvements

### DIFF
--- a/ebs-snapshot-copier.py
+++ b/ebs-snapshot-copier.py
@@ -1,109 +1,119 @@
 import boto3
 import collections
 import datetime
+import operator
 
-# Source Region - the region our instances are running in that we're backing up
-source_region = 'us-west-2' 
-copy_region = 'us-east-1'
 
-#ec = boto3.client('ec2', region_name=source_region)
+aws_account = 'XXXX'
+source = 'us-east-1'
+destination = 'sa-east-1'
 
-ec = boto3.client('ec2')
+client = boto3.client('ec2', source)
+foreign_client = boto3.client('ec2', destination)
 
-def lambda_handler(event, context):
-    reservations = ec.describe_instances(
+
+def copy_latest_snapshot():
+
+    response = client.describe_snapshots(
         Filters=[
-            { 'Name': 'tag:Backup', 'Values': ['Yes'] },
+            { 'Name': 'tag:Type', 'Values': ['Automated'] },
+            { 'Name': 'status', 'Values': ['completed'] },
+
         ]
-    ).get(
-        'Reservations', []
     )
 
-    instances = sum(
-        [
-            [i for i in r['Instances']]
-            for r in reservations
-        ], [])
+    if len(response['Snapshots']) == 0:
+        raise Exception("No automated snapshots found")
 
-    print "Found %d instances that need backing up" % len(instances)
 
-    to_tag = collections.defaultdict(list)
+    snapshots_per_project = {}
 
-    for instance in instances:
-        try:
-            retention_days = [
-                int(t.get('Value')) for t in instance['Tags']
-                if t['Key'] == 'Retention'][0]
-        except IndexError:
-            retention_days = 7
+    for snapshot in response['Snapshots']:
 
-        for dev in instance['BlockDeviceMappings']:
-            if dev.get('Ebs', None) is None:
-                continue
-            vol_id = dev['Ebs']['VolumeId']
-            dev_name = dev['DeviceName']
-            print "\tFound EBS volume %s (%s) on instance %s" % (
-                vol_id, dev_name, instance['InstanceId'])
+      if snapshot['Description'] not in snapshots_per_project.keys():
+          snapshots_per_project[snapshot['Description']] = {}
 
-            # figure out instance name if there is one
-            instance_name = ""
-            for tag in instance['Tags']:
-                if tag['Key'] != 'Name':
-                    continue
-                else:
-                    instance_name = tag['Value']
-            
-            description = '%s - %s (%s)' % ( instance_name, vol_id, dev_name )
 
-            # trigger snapshot
-            snap = ec.create_snapshot(
-                VolumeId=vol_id, 
-                Description=description
+      snapshots_per_project[snapshot['Description']][snapshot['SnapshotId']] = snapshot['StartTime']
+
+
+    for project in snapshots_per_project:
+
+      sorted_list = sorted(snapshots_per_project[project].items(), key=operator.itemgetter(1), reverse=True)
+
+      copy_name = project + " - " + sorted_list[0][1].strftime("%Y-%m-%d")
+
+      print("Checking if '" + copy_name + "' is copied")
+
+      # Check if the snapshot was copied into destination
+      response = foreign_client.describe_snapshots(
+          Filters=[
+              { 'Name': 'description', 'Values':[copy_name] },
+          ]
+      )
+
+      if len(response['Snapshots']) == 0:
+          print "'%s' not found" %copy_name
+
+          foreingSnapshot = foreign_client.copy_snapshot(
+              Description=  copy_name,
+              SourceRegion=source,
+              DestinationRegion=destination,
+              SourceSnapshotId= sorted_list[0][0],
+          )
+
+          print("Copying '" + copy_name + "' to " + destination)
+
+
+      if len(response['Snapshots']) == 1:
+          print "'%s' already copied!" %copy_name
+
+    return
+
+def remove_old_snapshots():
+
+    response = foreign_client.describe_snapshots(
+        OwnerIds=[aws_account],
+        Filters=[
+            { 'Name': 'status', 'Values': ['completed'] },
+        ]
+    )
+
+    if len(response['Snapshots']) == 0:
+        raise Exception("No snapshots in "+ destination + " found")
+
+    snapshots_per_project = {}
+
+    #print "snapshots: %s" %response['Snapshots']
+
+
+    for snapshot in response['Snapshots']:
+
+        short_description = (snapshot['Description'])[0:snapshot['Description'].find(')')+1]
+
+        if short_description not in snapshots_per_project.keys():
+            snapshots_per_project[short_description] = {}
+
+
+        snapshots_per_project[short_description][snapshot['SnapshotId']] = snapshot['StartTime']
+
+
+    for project in snapshots_per_project:
+        if len(snapshots_per_project[project]) > 1:
+            sorted_list = sorted(snapshots_per_project[project].items(), key=operator.itemgetter(1), reverse=True)
+
+            to_remove = [i[0] for i in sorted_list[1:]]
+
+            for snapshot in to_remove:
+                print("Removing " + snapshot)
+                foreign_client.delete_snapshot(
+                    SnapshotId=snapshot
                 )
-            
-            if (snap):
-                print "\t\tSnapshot %s created in %s of [%s]" % ( snap['SnapshotId'], source_region, description )
-            to_tag[retention_days].append(snap['SnapshotId'])
-            print "\t\tRetaining snapshot %s of volume %s from instance %s (%s) for %d days" % (
-                snap['SnapshotId'],
-                vol_id,
-                instance['InstanceId'],
-                instance_name,
-                retention_days,
-            )
 
-            ## trigger copy of above snapshot out-of-region if an additional snapshot destination is defined ##
-            if (copy_region):
-                # open a client connection to the destination 
-                addl_ec = boto3.client('ec2', region_name=copy_region)
-                addl_snap = addl_ec.copy_snapshot(
-                    SourceRegion=source_region,
-                    SourceSnapshotId=snap['SnapshotId'],
-                    Description=description,
-                    DestinationRegion=copy_region
-                )
 
-                if (addl_snap):
-                    print "\t\tSnapshot copy %s created in %s of [%s] from %s" % ( addl_snap['SnapshotId'], copy_region, description, source_region )
-                #to_tag[retention_days].append(addl_snap['SnapshotId'])
-                print "\t\tRetaining snapshot copy %s created in %s of volume %s from instance %s (%s) in %s for %d days" % (
-                    addl_snap['SnapshotId'],
-                    copy_region,
-                    vol_id,
-                    instance['InstanceId'],
-                    instance_name,
-                    source_region,
-                    retention_days,
-                )
+def lambda_handler(event, context):
+    copy_latest_snapshot()
+    remove_old_snapshots()
 
-    for retention_days in to_tag.keys():
-        delete_date = datetime.date.today() + datetime.timedelta(days=retention_days)
-        delete_fmt = delete_date.strftime('%Y-%m-%d')
-        print "Will delete %d snapshots on %s" % (len(to_tag[retention_days]), delete_fmt)
-        ec.create_tags(
-            Resources=to_tag[retention_days],
-            Tags=[
-                { 'Key': 'DeleteOn', 'Value': delete_fmt },
-                { 'Key': 'Type', 'Value': 'Automated' },
-            ]
-        )
+if __name__ == '__main__':
+  lambda_handler(None, None)


### PR DESCRIPTION
**ebs-snapshot-manager.py**
* Added aws account number instead of IAM user usage
* Added logic to remove snapshots with "DeleteOn" tag value less that today in order to delete older snapshots if the lambda function fails on a specific day. 

**ebs-snapshot-copier.py**
* Added aws account num instead of iam user usage 
* Added handling of snapshots being created  …
* Changed how snapshots are managed in the foreign region. Now only just one copy is allowed in the foreign region, according its StartDate snapshot field (based on https://github.com/pbudzon/aws-maintenance backup-rds.py)